### PR TITLE
fix: resolve merge conflict markers committed in 1.3.3 merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
-<<<<<<< release-1.3
 - 1.3.3
   - Sync now skips bad/unparseable certificates returned from Google CAS instead of failing the sync.
-=======
->>>>>>> main
 - 1.3.2
   - Fixed Sans Being passed through Extensions Data, Google does not like this.
 - 1.3.1

--- a/GCPCAS/Client/GCPCASClient.cs
+++ b/GCPCAS/Client/GCPCASClient.cs
@@ -271,7 +271,6 @@ public class GCPCASClient : IGCPCASClient
                             continue;
                         }
                     }
-<<<<<<< release-1.3
                     AnyCAPluginCertificate pluginCertificate = AnyCAPluginCertificateFromGCPCertificate(certificate);
 
                     // Mirror the subject handling the AnyCA Gateway performs when it builds the
@@ -287,9 +286,6 @@ public class GCPCASClient : IGCPCASClient
                     }
 
                     certificatesBuffer.Add(pluginCertificate);
-=======
-                    certificatesBuffer.Add(AnyCAPluginCertificateFromGCPCertificate(certificate));
->>>>>>> main
                     numberOfCertificates++;
                     _logger.LogDebug($"Found Certificate with name {certificate.CertificateName.CertificateId} {this.ToString()}");
                 }
@@ -317,10 +313,7 @@ public class GCPCASClient : IGCPCASClient
         {
             certificatesBuffer.CompleteAdding();
             _logger.LogDebug($"Fetched {certificatesBuffer.Count} certificates from GCP over {pageNumber} pages.");
-<<<<<<< release-1.3
             _logger.LogInformation($"[SYNC-DIAG] Handed {numberOfCertificates} certificate(s) to the AnyCA Gateway buffer; skipped {skippedCertificates} certificate(s) with subjects the gateway cannot parse. Review the per-record [SYNC-DIAG]/[SYNC-SKIP] lines above for details.");
-=======
->>>>>>> main
         }
         _logger.MethodExit();
         return numberOfCertificates;
@@ -380,7 +373,6 @@ public class GCPCASClient : IGCPCASClient
             status = EndEntityStatus.REVOKED;
             revocationReason = (int)certificate.RevocationDetails.RevocationState;
         }
-<<<<<<< release-1.3
 
         string caRequestId = certificate.CertificateName.CertificateId;
         string pem = certificate.PemCertificate;
@@ -391,8 +383,6 @@ public class GCPCASClient : IGCPCASClient
         // compare against what the Gateway stores / returns to Command on the /v2/certificate/search response.
         LogCertificateContentDiagnostics(caRequestId, pem, status, revocationDate, revocationReason);
 
-=======
->>>>>>> main
         _logger.MethodExit();
         return new AnyCAPluginCertificate
         {


### PR DESCRIPTION
## Problem

`main` does not compile: `dotnet build GCPCAS.sln` fails with 27 errors, mostly `CS8300: Merge conflict marker encountered`.

Commit `f4fbf10` ("Merge branch 'main' into release-1.3") was committed with unresolved conflict markers in `CHANGELOG.md` and `GCPCAS/Client/GCPCASClient.cs`. PR #26 then squash-merged that onto `main` as `df8c241`, carrying the markers with it.

## Triage

`git diff 1.3.3 main` is exactly the 13 marker lines — nothing else. Every conflict block resolves to the `release-1.3` side:

| Block | Location | Verdict |
|---|---|---|
| 1 | `CHANGELOG.md:1` | Keep 1.3.3 changelog entry |
| 2 | `GCPCASClient.cs:274` | Keep skip-unparseable-subject sync logic — this is the 1.3.3 feature; its helper method and `skippedCertificates` counter already live in the non-conflicted region |
| 3 | `GCPCASClient.cs:320` | Keep `[SYNC-DIAG]` summary log — dropping it orphans `skippedCertificates` |
| 4 | `GCPCASClient.cs:383` | Keep `caRequestId`/`pem` locals + diagnostics call — the `return` below already references those locals, so the `main` side cannot compile |

## Fix

Restore both files from the `1.3.3` tag, whose content is byte-identical to the intended resolution. Diff is 13 deletions (the marker lines only).

## Verification

- `git grep '<<<<<<<'` — no markers remain
- `dotnet build GCPCAS.sln` — 0 errors (was 27)
- `dotnet test` — 4 skipped (integration tests, gated on GCP env vars), 0 failed

## Note

`origin/release-1.3` still carries the markers at its tip (`f4fbf10`). It should get the same fix or be reset before anything else merges from it, or the markers will come back.